### PR TITLE
Add AgentLens to Tools (Other)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Starting in 2021, as LLMs evolved rapidly and the technology matured, we began t
 - [LangSmith](https://langsmith.io/) - A monitoring and debugging platform by the LangChain team that provides systematic performance tracking, error analysis, and logging for LLM-based applications.
 - [OpenLLM (by BentoML)](https://docs.bentoml.org/en/latest/openllm/) - A deployment tool from BentoML that simplifies serving various large language models in production environments.
 - [PromptLayer](https://promptlayer.com/) - A tool for tracking and analyzing prompt engineering experiments, helping optimize prompt performance and outcomes.
+- [AgentLens](https://github.com/Soufianeazz/agentlens) - Self-hosted LLM observability with built-in air-gap mode for regulated environments. Quality scoring, agent waterfalls, prompt debugger, GDPR-native compliance workflows. BSL 1.1 server + MIT SDK.
 
 [:arrow_up: Go to top](#top)
 


### PR DESCRIPTION
Adds AgentLens — a self-hosted LLM observability platform with built-in air-gap mode for regulated environments (finance, government, healthcare).

- Repo: https://github.com/Soufianeazz/agentlens
- Live demo: https://www.agentlens.one
- License: BSL 1.1 (server) + MIT (Python SDK)

Entry placed at the end of the section per current addition-order convention.