### PR TITLE
feat: add TWZRD Agent Intel to Tools (Other) section

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Starting in 2021, as LLMs evolved rapidly and the technology matured, we began t
 - [LangSmith](https://langsmith.io/) - A monitoring and debugging platform by the LangChain team that provides systematic performance tracking, error analysis, and logging for LLM-based applications.
 - [OpenLLM (by BentoML)](https://docs.bentoml.org/en/latest/openllm/) - A deployment tool from BentoML that simplifies serving various large language models in production environments.
 - [PromptLayer](https://promptlayer.com/) - A tool for tracking and analyzing prompt engineering experiments, helping optimize prompt performance and outcomes.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain trust scoring MCP server for AI agents on Solana. `score_agent` and `preflight_check` (free) return agent wallet reputation before autonomous task execution; `get_trust_receipt` (paid via x402 micropayment) issues a cryptographic audit trail. Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 [:arrow_up: Go to top](#top)
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Tools (Other)** section.

TWZRD Agent Intel is an MCP server that provides on-chain trust scoring for AI agents on Solana. In agentic LLMOps pipelines, agents often hand off tasks or make micropayments autonomously — TWZRD lets operators verify agent wallet identity and reputation *before* those actions happen.

**Tools:**
- `score_agent(wallet)` — free, returns on-chain trust score
- `preflight_check(wallet)` — free, returns go/no-go signal  
- `get_trust_receipt(wallet)` — paid (x402 micropayment), issues a cryptographic audit receipt

**MCP config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Fits alongside LangSmith (monitoring), OpenLLM (serving), and PromptLayer (tracking) as an operational layer for production agentic systems.