### PR TITLE
Add ModelPriceWatch to Tools (Other)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Starting in 2021, as LLMs evolved rapidly and the technology matured, we began t
 - [LangSmith](https://langsmith.io/) - A monitoring and debugging platform by the LangChain team that provides systematic performance tracking, error analysis, and logging for LLM-based applications.
 - [OpenLLM (by BentoML)](https://docs.bentoml.org/en/latest/openllm/) - A deployment tool from BentoML that simplifies serving various large language models in production environments.
 - [PromptLayer](https://promptlayer.com/) - A tool for tracking and analyzing prompt engineering experiments, helping optimize prompt performance and outcomes.
+- [ModelPriceWatch](https://modelpricewatch.com/) - Live pricing tracker for LLM APIs across 24 providers; a cheapest-input cost reference, auto-updated from provider pricing pages.
 
 [:arrow_up: Go to top](#top)
 


### PR DESCRIPTION
Thanks for maintaining awesome-llmops.

Disclosure: I maintain [ModelPriceWatch](https://modelpricewatch.com/), an open pricing tracker for LLM APIs — flagging per self-promotion norms.

There's no live-pricing/cost reference in the list yet, so I've proposed ModelPriceWatch under **Tools (Other)** — one line, plain do-follow link, no badge image. Happy to adjust placement or drop it.
